### PR TITLE
Updated pilet-webpack-plugin to allow placeholders in entry module file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 0.15.0 (tbd)
 
 - Moved `piral-cli-webpack` package to dedicated repository
+- Updated `pilet-webpack-plugin` to allow placeholders in entry module file name 

--- a/packages/pilet-webpack-plugin/src/index.ts
+++ b/packages/pilet-webpack-plugin/src/index.ts
@@ -34,6 +34,7 @@ export class PiletWebpackPlugin implements Plugin {
     const shortName = name.replace(/\W/gi, '');
     const prName = `wp4Chunkpr_${shortName}`;
     const [mainEntry] = Object.keys(config.entry);
+    const banner = `//@pilet v:0`;
 
     setEnvironment(this.variables);
     withExternals(config, this.externals);
@@ -41,7 +42,10 @@ export class PiletWebpackPlugin implements Plugin {
     const plugins = [
       new DefinePlugin(getDefineVariables(this.variables)),
       new BannerPlugin({
-        banner: `//@pilet v:0`,
+        banner: (data) => {
+          const { chunk } = data;
+          return chunk.name === mainEntry ? banner : '';
+        },
         entryOnly: true,
         raw: true,
       }),
@@ -62,6 +66,7 @@ export class PiletWebpackPlugin implements Plugin {
     const shortName = name.replace(/\W/gi, '');
     const prName = `wp4Chunkpr_${shortName}`;
     const [mainEntry] = Object.keys(config.entry);
+    const banner = `//@pilet v:1(${prName})`;
 
     setEnvironment(this.variables);
     withExternals(config, this.externals);
@@ -69,7 +74,10 @@ export class PiletWebpackPlugin implements Plugin {
     const plugins = [
       new DefinePlugin(getDefineVariables(this.variables)),
       new BannerPlugin({
-        banner: `//@pilet v:1(${prName})`,
+        banner: (data) => {
+          const { chunk } = data;
+          return chunk.name === mainEntry ? banner : '';
+        },
         entryOnly: true,
         raw: true,
       }),
@@ -98,11 +106,15 @@ export class PiletWebpackPlugin implements Plugin {
     setEnvironment(this.variables);
 
     const dependencies = getDependencies(importmap, config);
+    const banner = `//@pilet v:2(${prName},${JSON.stringify(dependencies)})`;
 
     const plugins = [
       new DefinePlugin(getDefineVariables(this.variables)),
       new BannerPlugin({
-        banner: `//@pilet v:2(${prName},${JSON.stringify(dependencies)})`,
+        banner: (data) => {
+          const { chunk } = data;
+          return chunk.name === mainEntry ? banner : '';
+        },
         entryOnly: true,
         raw: true,
       }),

--- a/packages/pilet-webpack-plugin/src/index.ts
+++ b/packages/pilet-webpack-plugin/src/index.ts
@@ -43,7 +43,6 @@ export class PiletWebpackPlugin implements Plugin {
       new BannerPlugin({
         banner: `//@pilet v:0`,
         entryOnly: true,
-        include: `${mainEntry}.js`,
         raw: true,
       }),
     ];
@@ -72,7 +71,6 @@ export class PiletWebpackPlugin implements Plugin {
       new BannerPlugin({
         banner: `//@pilet v:1(${prName})`,
         entryOnly: true,
-        include: `${mainEntry}.js`,
         raw: true,
       }),
     ];
@@ -106,7 +104,6 @@ export class PiletWebpackPlugin implements Plugin {
       new BannerPlugin({
         banner: `//@pilet v:2(${prName},${JSON.stringify(dependencies)})`,
         entryOnly: true,
-        include: `${mainEntry}.js`,
         raw: true,
       }),
     ];


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project
- [X] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [X] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description
This PR:
- Resolves the issue raised here: #1 
> Each instantiation of the BannerPlugin in packages/pilet-webpack-plugin/src/index.ts sets the following plugin configuration:
> 
>         entryOnly: true,
>         include: `${mainEntry}.js`,
> When webpack configuration is customized, the match process on the include property results in a false match, and the BannerPlugin will not emit the comment.
> 
> The entryOnly property (being set to true) is enough to indicate that a comment should be emitted in the entry module. The include property can be removed and makes the plugin usable in more webpack configurations.


### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
